### PR TITLE
Support Streaming Notifications

### DIFF
--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -55,6 +55,7 @@ class Viewpoint::EWS::Connection
       end
     end
 
+    # @httpcli.debug_dev = $stdout # For debugging requests and responses
     @httpcli.ssl_config.verify_mode = opts[:ssl_verify_mode] if opts[:ssl_verify_mode]
     @httpcli.ssl_config.ssl_version = opts[:ssl_version] if opts[:ssl_version]
     # Up the keep-alive so we don't have to do the NTLM dance as often.
@@ -116,7 +117,7 @@ class Viewpoint::EWS::Connection
   #   the response.
   def post(xmldoc)
     headers = { 'Content-Type' => 'text/xml' }
-    payload = oauth? ? [{ headers: headers.merge(@auth_header), body: xmldoc.to_s }] : [xmldoc, headers] 
+    payload = oauth? ? [{ headers: headers.merge(@auth_header), body: xmldoc.to_s }] : [xmldoc, headers]
     check_response(@httpcli.post(@endpoint, *payload))
   end
 

--- a/lib/ews/soap/builders/ews_builder.rb
+++ b/lib/ews/soap/builders/ews_builder.rb
@@ -759,6 +759,10 @@ module Viewpoint::EWS::SOAP
       @nbuild.SubscriptionId(subid)
     end
 
+    def streaming_subscription_id!(subid)
+      @nbuild[NS_EWS_TYPES].SubscriptionId(subid)
+    end
+
     def connection_timeout!(timeout)
       @nbuild.ConnectionTimeout(timeout)
     end

--- a/lib/ews/soap/builders/ews_builder.rb
+++ b/lib/ews/soap/builders/ews_builder.rb
@@ -759,6 +759,10 @@ module Viewpoint::EWS::SOAP
       @nbuild.SubscriptionId(subid)
     end
 
+    def connection_timeout!(timeout)
+      @nbuild.ConnectionTimeout(timeout)
+    end
+
     # @see http://msdn.microsoft.com/en-us/library/aa563455(v=EXCHG.140).aspx
     def pull_subscription_request(subopts)
       subscribe_all = subopts[:subscribe_to_all_folders] ? 'true' : 'false'

--- a/lib/ews/soap/exchange_notification.rb
+++ b/lib/ews/soap/exchange_notification.rb
@@ -47,7 +47,12 @@ module Viewpoint::EWS::SOAP
     #       }},
     #       ]
     def subscribe(subscriptions)
-      req = build_soap! do |type, builder|
+      req = subscribe_request subscriptions
+      do_soap_request(req, response_class: EwsResponse)
+    end
+
+    def subscribe_request(subscriptions)
+      build_soap! do |type, builder|
         if(type == :header)
         else
           builder.nbuild.Subscribe {
@@ -63,7 +68,6 @@ module Viewpoint::EWS::SOAP
           }
         end
       end
-      do_soap_request(req, response_class: EwsResponse)
     end
 
     # End a pull notification subscription.
@@ -106,17 +110,22 @@ module Viewpoint::EWS::SOAP
     # @see https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/getstreamingevents-operation GetStreamingEvents
     #
     # @param [String] subscription_id Subscription identifier
-    def get_streaming_events(subscription_id)
-      req = build_soap! do |type, builder|
-        if(type == :header)
-        else
+    # @param [Int] connection_timeout Number of minutes to keep the connection open
+    def get_streaming_events(subscription_id, connection_timeout = 30)
+      req = get_streaming_events_request subscription_id, connection_timeout
+      do_soap_request(req, response_class: EwsResponse)
+    end
+
+    def get_streaming_events_request(subscription_id, connection_timeout = 30)
+      build_soap! do |type, builder|
+        if(type != :header)
           builder.nbuild.GetStreamingEvents {
             builder.nbuild.parent.default_namespace = @default_ns
             builder.subscription_id!(subscription_id)
+            builder.connection_timeout!(connection_timeout)
           }
         end
       end
-      do_soap_request(req, response_class: EwsResponse)
     end
 
 
@@ -172,6 +181,13 @@ module Viewpoint::EWS::SOAP
       subscribe([{streaming_subscription_request: ssr}])
     end
 
-
+    def stream_subscribe_request(folder, evtypes)
+      ssr = {
+        :subscribe_to_all_folders => false,
+        :folder_ids => [ {:id => folder[:id], :change_key => folder[:change_key]} ],
+        :event_types=> evtypes,
+      }
+      subscribe_request([{streaming_subscription_request: ssr}])
+    end
   end #ExchangeNotification
 end

--- a/lib/ews/soap/exchange_notification.rb
+++ b/lib/ews/soap/exchange_notification.rb
@@ -1,7 +1,7 @@
 =begin
   This file is part of Viewpoint; the Ruby library for Microsoft Exchange Web Services.
 
-  Copyright Â© 2011 Dan Wanek <dan.wanek@gmail.com>
+  Copyright © 2011 Dan Wanek <dan.wanek@gmail.com>
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -96,6 +96,23 @@ module Viewpoint::EWS::SOAP
             builder.nbuild.parent.default_namespace = @default_ns
             builder.subscription_id!(subscription_id)
             builder.watermark!(watermark, NS_EWS_MESSAGES)
+          }
+        end
+      end
+      do_soap_request(req, response_class: EwsResponse)
+    end
+
+    # Used by streaming subscription clients to request notifications from the Client Access server
+    # @see https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/getstreamingevents-operation GetStreamingEvents
+    #
+    # @param [String] subscription_id Subscription identifier
+    def get_streaming_events(subscription_id)
+      req = build_soap! do |type, builder|
+        if(type == :header)
+        else
+          builder.nbuild.GetStreamingEvents {
+            builder.nbuild.parent.default_namespace = @default_ns
+            builder.subscription_id!(subscription_id)
           }
         end
       end

--- a/lib/ews/soap/exchange_notification.rb
+++ b/lib/ews/soap/exchange_notification.rb
@@ -1,7 +1,7 @@
 =begin
   This file is part of Viewpoint; the Ruby library for Microsoft Exchange Web Services.
 
-  Copyright © 2011 Dan Wanek <dan.wanek@gmail.com>
+  Copyright Â© 2011 Dan Wanek <dan.wanek@gmail.com>
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -139,6 +139,20 @@ module Viewpoint::EWS::SOAP
       }
       psr[:watermark] = watermark if watermark
       subscribe([{push_subscription_request: psr}])
+    end
+
+    # Create a pull subscription to a single folder
+    # @param folder [Hash] a hash with the folder :id and :change_key
+    # @param evtypes [Array] the events you would like to subscribe to.
+    # @param timeout [Fixnum] http://msdn.microsoft.com/en-us/library/aa565201.aspx
+    # @param watermark [String] http://msdn.microsoft.com/en-us/library/aa565886.aspx
+    def stream_subscribe_folder(folder, evtypes)
+      ssr = {
+        :subscribe_to_all_folders => false,
+        :folder_ids => [ {:id => folder[:id], :change_key => folder[:change_key]} ],
+        :event_types=> evtypes,
+      }
+      subscribe([{streaming_subscription_request: ssr}])
     end
 
 

--- a/lib/ews/soap/exchange_notification.rb
+++ b/lib/ews/soap/exchange_notification.rb
@@ -121,7 +121,9 @@ module Viewpoint::EWS::SOAP
         if(type != :header)
           builder.nbuild.GetStreamingEvents {
             builder.nbuild.parent.default_namespace = @default_ns
-            builder.subscription_id!(subscription_id)
+            builder.nbuild.SubscriptionIds {
+              builder.streaming_subscription_id!(subscription_id)
+            }
             builder.connection_timeout!(connection_timeout)
           }
         end

--- a/lib/ews/soap/exchange_synchronization.rb
+++ b/lib/ews/soap/exchange_synchronization.rb
@@ -71,22 +71,24 @@ module Viewpoint::EWS::SOAP
     #     :sync_state => myBase64id,
     #     :max_changes_returned => 256 }
     def sync_folder_items(opts)
-      opts = opts.clone
-      req = build_soap! do |type, builder|
-        if(type == :header)
-        else
+      req = sync_folder_items_request opts
+      do_soap_request(req, response_class: EwsResponse)
+    end
+
+    def sync_folder_items_request(opts)
+      build_soap! do |type, builder|
+        if type != :header
           builder.nbuild.SyncFolderItems {
             builder.nbuild.parent.default_namespace = @default_ns
-            builder.item_shape!(opts[:item_shape])
+            builder.item_shape!(opts[:item_shape] || { base_shape: :default })
             builder.sync_folder_id!(opts[:sync_folder_id]) if opts[:sync_folder_id]
             builder.sync_state!(opts[:sync_state]) if opts[:sync_state]
             builder.ignore!(opts[:ignore]) if opts[:ignore]
-            builder.max_changes_returned!(opts[:max_changes_returned])
+            builder.max_changes_returned!(opts[:max_changes_returned] || 256)
             builder.sync_scope!(opts[:sync_scope]) if opts[:sync_scope]
           }
         end
       end
-      do_soap_request(req, response_class: EwsResponse)
     end
 
   end #ExchangeSynchronization

--- a/lib/ews/types/generic_folder.rb
+++ b/lib/ews/types/generic_folder.rb
@@ -241,6 +241,11 @@ module Viewpoint::EWS::Types
       @synced
     end
 
+    def sync_items_request(sync_state: nil, sync_amount: 256, item_shape: { base_shape: :default })
+      ews.sync_folder_items_request item_shape: item_shape, sync_folder_id: self.folder_id,
+        max_changes_returned: sync_amount, sync_state: (sync_state || @sync_state)
+    end
+
     # Subscribe this folder to events.  This method initiates an Exchange pull
     # type subscription.
     #
@@ -297,6 +302,12 @@ module Viewpoint::EWS::Types
       end
     end
 
+    def stream_subscribe_request(evtypes = [:all])
+      event_types = normalize_event_names(evtypes)
+      folder = { id: self.id, change_key: self.change_key }
+      ews.stream_subscribe_request(folder, event_types)
+    end
+
     # Check if there is a subscription for this folder.
     # @return [Boolean] Are we subscribed to this folder?
     def subscribed?
@@ -342,10 +353,10 @@ module Viewpoint::EWS::Types
 
     # Checks a subscribed folder for events
     # @return [Array] An array of Event items
-    def get_streaming_events
+    def get_streaming_events(connection_timeout = 30)
       begin
         if @subscription_id
-          resp = ews.get_streaming_events(@subscription_id)
+          resp = ews.get_streaming_events(@subscription_id, connection_timeout)
           rmsg = resp.response_messages[0]
           # @todo if parms[:more_events] # get more events
           rmsg.events.collect{|ev|

--- a/lib/ews/types/generic_folder.rb
+++ b/lib/ews/types/generic_folder.rb
@@ -1,7 +1,7 @@
 =begin
   This file is part of Viewpoint; the Ruby library for Microsoft Exchange Web Services.
 
-  Copyright © 2011 Dan Wanek <dan.wanek@gmail.com>
+  Copyright Â© 2011 Dan Wanek <dan.wanek@gmail.com>
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -278,6 +278,19 @@ module Viewpoint::EWS::Types
       if rmsg.success?
         @subscription_id = rmsg.subscription_id
         @watermark = rmsg.watermark
+        true
+      else
+        raise EwsSubscriptionError, "Could not subscribe: #{rmsg.code}: #{rmsg.message_text}"
+      end
+    end
+
+    def stream_subscribe(evtypes = [:all])
+      event_types = normalize_event_names(evtypes)
+      folder = {id: self.id, change_key: self.change_key}
+      resp = ews.stream_subscribe_folder(folder, event_types)
+      rmsg = resp.response_messages.first
+      if rmsg.success?
+        @subscription_id = rmsg.subscription_id
         true
       else
         raise EwsSubscriptionError, "Could not subscribe: #{rmsg.code}: #{rmsg.message_text}"


### PR DESCRIPTION
This PR adds the ability to subscribe to and retrieve streaming notifications from EWS.
It also separates the logic that generates the XML requests from the logic that performs the request to allow us to send the requests ourselves through EventMachine or other means as needed.