### PR TITLE
Bring back ability to hand in http_opts to Connection

### DIFF
--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -44,6 +44,10 @@ class Viewpoint::EWS::Connection
     @credentials[:type] == :oauth
   end
 
+  def basic?
+    @credentials[:type] == :basic
+  end
+
   def init_http_client(opts)
     @httpcli = HTTPClient.new({}.tap do |init_options|
       init_options[:agent_name] = opts[:user_agent] if opts[:user_agent]

--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -118,8 +118,7 @@ class Viewpoint::EWS::Connection
   private
 
   def check_response(resp)
-    status = oauth? ? resp.code : resp.status
-    case status
+    case resp.status
     when 200
       resp.body
     when 302

--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -49,10 +49,13 @@ class Viewpoint::EWS::Connection
   end
 
   def init_http_client(opts)
-    @httpcli = HTTPClient.new({}.tap do |init_options|
-      init_options[:agent_name] = opts[:user_agent] if opts[:user_agent]
-      init_options[:force_basic_auth] = true if basic?
-    end)
+    init_options = {}.tap do |init|
+      init[:agent_name] = opts[:user_agent] if opts[:user_agent]
+      init[:force_basic_auth] = true if basic?
+    end
+    # NOTE: HTTPClient does not handle being handed an empty object literal correctly (it accidentally sets
+    #   proxy to the object literal, then blows up)
+    @httpcli = init_options.keys.empty? ? HTTPClient.new : HTTPClient.new(init_options)
 
     if opts[:trust_ca]
       @httpcli.ssl_config.clear_cert_store

--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -45,7 +45,10 @@ class Viewpoint::EWS::Connection
   end
 
   def init_http_client(opts)
-    @httpcli = opts[:user_agent] ? HTTPClient.new(agent_name: opts[:user_agent]) : HTTPClient.new
+    @httpcli = HTTPClient.new({}.tap do |init_options|
+      init_options[:agent_name] = opts[:user_agent] if opts[:user_agent]
+      init_options[:force_basic_auth] = true if basic?
+    end)
 
     if opts[:trust_ca]
       @httpcli.ssl_config.clear_cert_store

--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -141,6 +141,8 @@ class Viewpoint::EWS::Connection
       else
         raise Errors::ServerError.new("Internal Server Error. Message: #{resp.body}", resp)
       end
+    when 503
+      raise Errors::ServerError.new("Service Unavailable. Message: #{resp.body}", resp)
     else
       raise Errors::ResponseError.new("HTTP Error Code: #{resp.status}, Msg: #{resp.body}", resp)
     end

--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -69,7 +69,8 @@ class Viewpoint::EWS::Connection
     @httpcli.ssl_config.verify_mode = opts[:ssl_verify_mode] if opts[:ssl_verify_mode]
     @httpcli.ssl_config.ssl_version = opts[:ssl_version] if opts[:ssl_version]
     # Up the keep-alive so we don't have to do the NTLM dance as often.
-    @httpcli.keep_alive_timeout = 60
+    @httpcli.keep_alive_timeout = opts[:keep_alive_timeout] ? opts[:keep_alive_timeout].to_i : 60
+    @httpcli.protocol_version = opts[:protocol_version] if opts[:protocol_version]
     @httpcli.receive_timeout = opts[:receive_timeout] if opts[:receive_timeout]
     @httpcli.connect_timeout = opts[:connect_timeout] if opts[:connect_timeout]
 

--- a/lib/ews/ews_client.rb
+++ b/lib/ews/ews_client.rb
@@ -48,7 +48,7 @@ class Viewpoint::EWSClient
     credentials = credentials.dup
     opts = opts.dup
     http_klass = opts[:http_class] || Viewpoint::EWS::Connection
-    con = http_klass.new(@endpoint, @username, credentials)
+    con = http_klass.new(@endpoint, @username, credentials, opts[:http_opts] || {})
     @ews = SOAP::ExchangeWebService.new(con, opts)
   end
 

--- a/lib/ews/soap/parsers/ews_parser.rb
+++ b/lib/ews/soap/parsers/ews_parser.rb
@@ -28,7 +28,7 @@ module Viewpoint::EWS::SOAP
 
     def parse(opts = {})
       opts[:response_class] ||= EwsSoapResponse
-      @soap_resp.gsub!(/&#x([0-8bcef]|1[0-9a-f]);/i, '')
+      @soap_resp.gsub!(/&#x([0-8bcef]|1[0-9a-f]|FFFF|FFFE);/i, '')
       sax_parser.parse(@soap_resp)
       opts[:response_class].new @sax_doc.struct
     end

--- a/spec/unit/ews_parser_spec.rb
+++ b/spec/unit/ews_parser_spec.rb
@@ -21,4 +21,18 @@ describe "Exchange Response Parser Functionality" do
     resp.body.should == error_body
   end
 
+  it 'removes illegal character &#xFFFF;' do
+    soap_resp = load_soap "find_folder", :response
+    soap_resp.insert(soap_resp.index("TestFolder"), '&#xFFFF;')
+    resp = Viewpoint::EWS::SOAP::EwsParser.new(soap_resp).parse
+    resp.body.should == success_body
+  end
+
+  it 'removes illegal character &#xFFFE;' do
+    soap_resp = load_soap "find_folder", :response
+    soap_resp.insert(soap_resp.index("TestFolder"), '&#xFFFE;')
+    resp = Viewpoint::EWS::SOAP::EwsParser.new(soap_resp).parse
+    resp.body.should == success_body
+  end
+
 end


### PR DESCRIPTION
* Remove use of HTTParty, and instead use the regular HTTPClient to make oauth calls. There's no benefit to using HTTParty for these calls, and it's more confusing for debugging.

* Add a proxy_url option for enabling proxied calls

* Add a debug option for turning on debug mode without having to modify the gem