### PR TITLE
Handle EWS 503 Error

### DIFF
--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -141,6 +141,8 @@ class Viewpoint::EWS::Connection
       else
         raise Errors::ServerError.new("Internal Server Error. Message: #{resp.body}", resp)
       end
+    when 503
+      raise Errors::ServerError.new("Service Unavailable. Message: #{resp.body}", resp)
     else
       raise Errors::ResponseError.new("HTTP Error Code: #{resp.status}, Msg: #{resp.body}", resp)
     end


### PR DESCRIPTION
Fixes the following Honeybadger: https://app.honeybadger.io/projects/1590/faults/78767500%20%EF%BB%BF

This PR adds a check for a 503 (Service Unavailable) response code in `Connection` which raises a `ServerError` with the appropriate message, similarly to when there is a 500.