### PR TITLE
Remove illegal characters FFFF and FFFE for EWS parser

### DIFF
--- a/lib/ews/soap/parsers/ews_parser.rb
+++ b/lib/ews/soap/parsers/ews_parser.rb
@@ -28,7 +28,7 @@ module Viewpoint::EWS::SOAP
 
     def parse(opts = {})
       opts[:response_class] ||= EwsSoapResponse
-      @soap_resp.gsub!(/&#x([0-8bcef]|1[0-9a-f]);/i, '')
+      @soap_resp.gsub!(/&#x([0-8bcef]|1[0-9a-f]|FFFF|FFFE);/i, '')
       sax_parser.parse(@soap_resp)
       opts[:response_class].new @sax_doc.struct
     end

--- a/spec/unit/ews_parser_spec.rb
+++ b/spec/unit/ews_parser_spec.rb
@@ -21,4 +21,18 @@ describe "Exchange Response Parser Functionality" do
     resp.body.should == error_body
   end
 
+  it 'removes illegal character &#xFFFF;' do
+    soap_resp = load_soap "find_folder", :response
+    soap_resp.insert(soap_resp.index("TestFolder"), '&#xFFFF;')
+    resp = Viewpoint::EWS::SOAP::EwsParser.new(soap_resp).parse
+    resp.body.should == success_body
+  end
+
+  it 'removes illegal character &#xFFFE;' do
+    soap_resp = load_soap "find_folder", :response
+    soap_resp.insert(soap_resp.index("TestFolder"), '&#xFFFE;')
+    resp = Viewpoint::EWS::SOAP::EwsParser.new(soap_resp).parse
+    resp.body.should == success_body
+  end
+
 end


### PR DESCRIPTION
This removes the illegal characters `&#xFFFE;` `&#xFFFF;` before we parse the XML :D

Sources of these being illegal :D
http://www.unicode.org/charts/PDF/UFFF0.pdf
https://www.w3.org/TR/REC-xml/#charsets